### PR TITLE
conditional schema dump

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,7 +228,8 @@ int main(int argc, char* argv[]) {
   auto syncedSchemas = SyncedSchema::resolveIndexedSchema(
       std::move(indexedSyncedSchemas), codeProperties);
 
-  SyncedSchema::dumpSchemas(syncedSchemas, outputDirectory);
+  if (dumpSchemas)
+    SyncedSchema::dumpSchemas(syncedSchemas, outputDirectory);
 
   if (combineSourceFiles) {
     std::ofstream source(outputDirectory / "schemas.cpp");


### PR DESCRIPTION
synced schema dump always was created, no need to do it without `-d` 